### PR TITLE
Refactor cssclass implementation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,27 +1,26 @@
-export type CSSClassObject = {
-  [key: string]: boolean
-}
+export type CSSClassObject = Record<string, boolean>
 
-const reject = (obj: CSSClassObject) => {
-  return Object.keys(obj)
-    .map((i) => !!obj[i] && i)
+type CSSClassValue = string | CSSClassObject
+
+const normalizeClassName = (className: string): string => className.trim()
+
+const isString = (value: CSSClassValue): value is string => typeof value === 'string'
+
+const classObjectToList = (obj: CSSClassObject): string[] =>
+  Object.entries(obj)
+    .filter(([, enabled]) => Boolean(enabled))
+    .map(([className]) => normalizeClassName(className))
     .filter(Boolean)
-    .join(` `)
+
+const collectClassNames = (value: CSSClassValue): string[] => {
+  if (isString(value)) {
+    const normalized = normalizeClassName(value)
+    return normalized ? [normalized] : []
+  }
+
+  return classObjectToList(value)
 }
 
-export function cssclass(...values: Array<string | CSSClassObject>): string {
-  const classNames: string[] = []
-  values.forEach((value: string | CSSClassObject) => {
-    if (typeof value === 'string') {
-      if (value.trim().length > 0) {
-        classNames.push(value)
-      }
-    } else {
-      const mappedValue = reject(value)
-      if (mappedValue.trim().length > 0) {
-        classNames.push(mappedValue)
-      }
-    }
-  })
-  return classNames.join(' ')
+export function cssclass(...values: CSSClassValue[]): string {
+  return values.flatMap(collectClassNames).join(' ')
 }


### PR DESCRIPTION
## Summary
- refactor the `cssclass` utility to use helper functions for normalization and filtering
- ensure class names from objects are trimmed and ignored when empty, keeping the output clean

## Testing
- npm run ci-test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691b5184cacc8332a71b58ed3e4532b7)